### PR TITLE
Refactor out global variables in Messaging class

### DIFF
--- a/farmbot.rb
+++ b/farmbot.rb
@@ -39,8 +39,8 @@ else
 end
 puts 'OK'
 
-puts "uuid            #{$info_uuid}"
-puts "token           #{$info_token}"
+puts "uuid            #{Messaging.current.uuid}"
+puts "token           #{Messaging.current.token}"
 if $controller_disable == 0
   print 'controller      '
   require_relative 'lib/controller'

--- a/farmtalk.rb
+++ b/farmtalk.rb
@@ -28,8 +28,8 @@ print 'synchronization '
 require_relative 'lib/messaging'
 puts 'OK'
 
-puts "uuid            #{$info_uuid}"
-puts "token           #{$info_token}"
+puts "uuid            #{Messaging.current.uuid}"
+puts "token           #{Messaging.current.token}"
 
 puts 'press key to stop'
 gets.chomp

--- a/lib/messaging.rb
+++ b/lib/messaging.rb
@@ -1,16 +1,3 @@
-
-
 require_relative 'messaging/messaging'
 
-# The unfortunate use of globals in this project: The SocketIO library we use to
-# talk to skynet stores blocks as lambdas and calls them later under a different
-# context than that which they were defined. This means that even though we
-# define the .on() events within the `Device` class, self does NOT refer to the
-# device, but rather the current socket connection. Using a global is a quick
-# fix to ensure we always have easy access to the device. Pull requests welcome.
-
-$messaging = Messaging.new
-$messaging.start
-
-#TODO: Daemonize this script:
-#https://www.ruby-toolbox.com/categories/daemonizing
+Messaging.current.start

--- a/lib/messaging/messagehandler.rb
+++ b/lib/messaging/messagehandler.rb
@@ -131,7 +131,7 @@ class MessageHandler
 
   def send_message(destination, command)
     @dbaccess.write_to_log(3,"to #{destination} : #{command.to_s}")
-    $messaging.send_message(destination, command)
+    Messaging.current.send_message(destination, command)
   end
 
   def split_message(message, message_obj)

--- a/lib/messaging/messaging.rb
+++ b/lib/messaging/messaging.rb
@@ -11,9 +11,6 @@ require_relative 'messagehandler.rb'
 # The Device class is temporarily inheriting from Tim's HardwareInterface.
 # Eventually, we should merge the two projects, but this is good enough for now.
 class Messaging
-
-  include Credentials, WebSocket
-
   class << self
     attr_accessor :current
 
@@ -24,6 +21,8 @@ class Messaging
 
   attr_accessor :socket, :uuid, :token, :identified, :confirmed,
     :confirmation_id
+
+  include Credentials, WebSocket
 
   # On instantiation #new sets the @uuid, @token variables, connects to skynet
   def initialize
@@ -42,7 +41,7 @@ class Messaging
   end
 
   def send_message(devices, message_hash )
-    @socket.emit("message", devices: devices, message: message_hash})
+    @socket.emit("message", devices: devices, message: message_hash)
   end
 
   # Acts as the entry point for message traffic captured from MeshBlu.

--- a/lib/messaging/messaging.rb
+++ b/lib/messaging/messaging.rb
@@ -14,56 +14,48 @@ class Messaging
 
   include Credentials, WebSocket
 
+  class << self
+    attr_accessor :current
+
+    def current
+      @current ||= self.new
+    end
+  end
+
   attr_accessor :socket, :uuid, :token, :identified, :confirmed,
     :confirmation_id
 
   # On instantiation #new sets the @uuid, @token variables, connects to skynet
   def initialize
-    super
     identified = false
     creds      = credentials
     @uuid      = creds[:uuid]
     @token     = creds[:token]
+    # Still pointing to old URL?
     @socket    = SocketIO::Client::Simple.connect 'http://skynet.im:80'
     @confirmed = false
   end
 
   def start
-    $info_uuid              = @uuid
-    $info_token             = @token
-    $info_last_msg_received = nil
-    $info_nr_msg_received   = 0
-
     create_socket_events
-
     @message_handler  = MessageHandler.new
   end
 
   def send_message(devices, message_hash )
-    @socket.emit("message",{:devices => devices, :message => message_hash})
+    @socket.emit("message", devices: devices, message: message_hash})
   end
 
-  # Acts as the entry point for message traffic captured from Skynet.im.
-  # This method is a stub for now until I have time to merge into Tim's
-  # controller code. Returns a MessageHandler object (a class yet created).
-  #def handle_message(channel, message)
+  # Acts as the entry point for message traffic captured from MeshBlu.
   def handle_message(message)
-
-    #puts "> message received at #{Time.now}"
-    #puts message
-
-    $info_last_msg_received = Time.now
-    $info_nr_msg_received  += 1
-
-    if message.class.to_s == 'Hash'
+    case message.class
+    when Hash
       @message_handler.handle_message(message)
-    end
-
-    if message.class.to_s == 'String'
+    when String
       message_hash = JSON.parse(message)
       @message_handler.handle_message(message_hash)
+    else
+      raise "Can't handle messages of class #{message.class}"
     end
-
   rescue
     raise "Runtime error while attempting to parse message: #{message}."
   end

--- a/lib/messaging/web_socket.rb
+++ b/lib/messaging/web_socket.rb
@@ -1,6 +1,6 @@
 require 'socket.io-client-simple'
 #require_relative 'socket.io-client-simple.rb'
-                                                   
+
 module WebSocket
   ### Bootstraps all the events for skynet in the correct order. Returns Int.
   def create_socket_events
@@ -13,12 +13,12 @@ module WebSocket
   #Handles self identification on skynet by responding to the :indentify with a
   #:identity event / credentials Hash.
   def create_identify_event
-    $messaging.socket.on :identify do |data|
+    Messaging.current.socket.on :identify do |data|
       self.emit :identity, {
-        uuid:     $messaging.uuid,
-        token:    $messaging.token,
+        uuid:     Messaging.current.uuid,
+        token:    Messaging.current.token,
         socketid: data['socketid']}
-      $messaging.identified = true
+      Messaging.current.identified = true
     end
   end
 
@@ -28,8 +28,8 @@ module WebSocket
     #  $skynet.handle_message(channel, message)
     #end
 
-    $messaging.socket.on :message do |message|
-      $messaging.handle_message(message)
+    Messaging.current.socket.on :message do |message|
+      Messaging.current.handle_message(message)
     end
   end
 

--- a/lib/messaging/web_socket.rb
+++ b/lib/messaging/web_socket.rb
@@ -13,24 +13,16 @@ module WebSocket
   #Handles self identification on skynet by responding to the :indentify with a
   #:identity event / credentials Hash.
   def create_identify_event
-    Messaging.current.socket.on :identify do |data|
-      self.emit :identity, {
-        uuid:     Messaging.current.uuid,
-        token:    Messaging.current.token,
-        socketid: data['socketid']}
-      Messaging.current.identified = true
+    socket.on :identify do |data|
+      auth_data = {uuid: uuid, token: token, socketid: data['socketid']}
+      socket.emit :identity, auth_data
+      identified = true
     end
   end
 
   ### Routes all skynet messages to handle_event() for interpretation.
   def create_message_event
-    #@socket.on :message do |channel, message|
-    #  $skynet.handle_message(channel, message)
-    #end
-
-    Messaging.current.socket.on :message do |message|
-      Messaging.current.handle_message(message)
-    end
+    socket.on(:message) { |message| Messaging.current.handle_message(message) }
   end
 
 end

--- a/spec/messaging/messagehandler_emergency_stop_spec.rb
+++ b/spec/messaging/messagehandler_emergency_stop_spec.rb
@@ -18,8 +18,8 @@ describe MessageHandlerEmergencyStop do
 
     $status = Status.new
 
-    $messaging = MessagingTest.new
-    $messaging.reset
+    Messaging.current = MessagingTest.new
+    Messaging.current.reset
 
     @handler = MessageHandlerEmergencyStop.new
     @main_handler = MessageHandler.new
@@ -31,16 +31,16 @@ describe MessageHandlerEmergencyStop do
     list = @handler.whitelist
     expect(list.count).to eq(2)
   end
-  
+
   it "message handler emergency stop" do
     message = MessageHandlerMessage.new
     message.handled = false
     message.handler = @main_handler
 
     @handler.emergency_stop(message)
-    
+
     expect($status.emergency_stop).to eq(true)
-    expect($messaging.message[:message_type]).to eq('confirmation')
+    expect(Messaging.current.message[:message_type]).to eq('confirmation')
   end
 
   it "message handler emergency stop reset" do
@@ -51,7 +51,7 @@ describe MessageHandlerEmergencyStop do
     @handler.emergency_stop_reset(message)
 
     expect($status.emergency_stop).to eq(false)
-    expect($messaging.message[:message_type]).to eq('confirmation')
+    expect(Messaging.current.message[:message_type]).to eq('confirmation')
   end
 
 

--- a/spec/messaging/messagehandler_log_spec.rb
+++ b/spec/messaging/messagehandler_log_spec.rb
@@ -14,15 +14,15 @@ describe MessageHandlerLog do
 
     $status = Status.new
 
-    $messaging = MessagingTest.new
-    $messaging.reset
+    Messaging.current = MessagingTest.new
+    Messaging.current.reset
 
     @handler = MessageHandlerLog.new
     @main_handler = MessageHandler.new
   end
 
   ## logs
-  
+
   it "white list" do
     list = @handler.whitelist
     expect(list.count).to eq(1)
@@ -47,7 +47,7 @@ describe MessageHandlerLog do
 
     @handler.read_logs(message)
 
-    return_list = $messaging.message
+    return_list = Messaging.current.message
 
     # check if the logged lines are present in the message
 
@@ -68,7 +68,7 @@ describe MessageHandlerLog do
 
     expect(found_in_list_1).to eq(true)
     expect(found_in_list_2).to eq(true)
-    expect($messaging.message[:message_type]).to eq('read_logs_response')
+    expect(Messaging.current.message[:message_type]).to eq('read_logs_response')
   end
 
 end

--- a/spec/messaging/messagehandler_measurements_spec.rb
+++ b/spec/messaging/messagehandler_measurements_spec.rb
@@ -14,8 +14,8 @@ describe MessageHandlerMeasurement do
 
     $status = Status.new
 
-    $messaging = MessagingTest.new
-    $messaging.reset
+    Messaging.current = MessagingTest.new
+    Messaging.current.reset
 
     @handler = MessageHandlerMeasurement.new
     @main_handler = MessageHandler.new
@@ -27,7 +27,7 @@ describe MessageHandlerMeasurement do
     list = @handler.whitelist
     expect(list.count).to eq(2)
   end
-  
+
   it "read measurements" do
 
     # write a measurement
@@ -44,14 +44,14 @@ describe MessageHandlerMeasurement do
 
     # check if the created item is into the list to send
     found_in_list = false
-    $messaging.message[:measurements].each do |item|
+    Messaging.current.message[:measurements].each do |item|
       if item['value'] == measurement_value and item['ext_info'] == measurement_text
         found_in_list = true
       end
     end
 
     expect(found_in_list).to eq(true)
-    expect($messaging.message[:message_type]).to eq('read_measurements_response')
+    expect(Messaging.current.message[:message_type]).to eq('read_measurements_response')
   end
 
   it "delete measurement" do
@@ -113,7 +113,7 @@ describe MessageHandlerMeasurement do
     expect(found_in_list_2).to eq(true)
     expect(found_in_list_1_after).to eq(false)
     expect(found_in_list_2_after).to eq(false)
-    expect($messaging.message[:message_type]).to eq('confirmation')
+    expect(Messaging.current.message[:message_type]).to eq('confirmation')
 
   end
 

--- a/spec/messaging/messagehandler_parameters_spec.rb
+++ b/spec/messaging/messagehandler_parameters_spec.rb
@@ -14,8 +14,8 @@ describe MessageHandlerParameter do
 
     $status = Status.new
 
-    $messaging = MessagingTest.new
-    $messaging.reset
+    Messaging.current = MessagingTest.new
+    Messaging.current.reset
 
     @handler = MessageHandlerParameter.new
     @main_handler = MessageHandler.new
@@ -47,7 +47,7 @@ describe MessageHandlerParameter do
 
     @handler.read_parameters(message)
 
-    return_list = $messaging.message
+    return_list = Messaging.current.message
 
     # check if the parameters are present in the message
 
@@ -67,7 +67,7 @@ describe MessageHandlerParameter do
 
     expect(found_in_list_1).to eq(true)
     expect(found_in_list_2).to eq(true)
-    expect($messaging.message[:message_type]).to eq('read_parameters_response')
+    expect(Messaging.current.message[:message_type]).to eq('read_parameters_response')
   end
 
   it "write parameters" do
@@ -85,9 +85,9 @@ describe MessageHandlerParameter do
     message.handled = false
     message.handler = @main_handler
     #message.payload = {'ids' => [id_1,id_2]}
-    message.payload = 
+    message.payload =
       {
-        'parameters' => 
+        'parameters' =>
           [
             {'name' => parameter_name_1, 'type' => 1, 'value' => parameter_value_1},
             {'name' => parameter_name_2, 'type' => 1, 'value' => parameter_value_2}
@@ -105,7 +105,7 @@ describe MessageHandlerParameter do
 
     expect(value_read_1).to eq(parameter_value_1)
     expect(value_read_2).to eq(parameter_value_2)
-    expect($messaging.message[:message_type]).to eq('confirmation')
+    expect(Messaging.current.message[:message_type]).to eq('confirmation')
 
   end
 
@@ -119,7 +119,7 @@ describe MessageHandlerParameter do
 
     @handler.write_parameters(message)
 
-    expect($messaging.message[:message_type]).to eq('error')
+    expect(Messaging.current.message[:message_type]).to eq('error')
 
   end
 

--- a/spec/messaging/messagehandler_schedule_spec.rb
+++ b/spec/messaging/messagehandler_schedule_spec.rb
@@ -17,15 +17,15 @@ describe MessageHandlerSchedule do
 
     $status = Status.new
 
-    $messaging = MessagingTest.new
-    $messaging.reset
+    Messaging.current = MessagingTest.new
+    Messaging.current.reset
 
     @handler = MessageHandlerSchedule.new
     @main_handler = MessageHandler.new
   end
 
   ## commands / scheduling
-  
+
   it "white list" do
     list = @handler.whitelist
     expect(list.count).to eq(2)
@@ -54,7 +54,7 @@ describe MessageHandlerSchedule do
 
     # save the new command in the database
 
-    command = 
+    command =
       {
         'action'        => action        ,
         'delay'         => delay         ,
@@ -99,7 +99,7 @@ describe MessageHandlerSchedule do
     expect(line.pin_value_2  ).to eq(pin_value2   )
     expect(line.pin_mode     ).to eq(pin_mode     )
     expect(line.pin_time     ).to eq(pin_time     )
-    
+
   end
 
   it "save single command" do
@@ -120,11 +120,11 @@ describe MessageHandlerSchedule do
     pin_mode      = rand(9999999).to_i
     pin_time      = rand(9999999).to_i
     ext_info      = rand(9999999).to_s
-    delay         = rand(     99).to_i + 10 
+    delay         = rand(     99).to_i + 10
 
     # save the new command in the database
 
-    command = 
+    command =
       {
         'action'        => action        ,
         'delay'         => delay         ,
@@ -165,7 +165,7 @@ describe MessageHandlerSchedule do
     expect(line.pin_value_2  ).to eq(pin_value2   )
     expect(line.pin_mode     ).to eq(pin_mode     )
     expect(line.pin_time     ).to eq(pin_time     )
-    
+
   end
 
   it "handle single command" do
@@ -193,9 +193,9 @@ describe MessageHandlerSchedule do
     message = MessageHandlerMessage.new
     message.handled = false
     message.handler = @main_handler
-    message.payload = 
+    message.payload =
       {
-        'command'  => 
+        'command'  =>
         {
           'delay'  => delay      ,
           'action' => action     ,
@@ -236,7 +236,7 @@ describe MessageHandlerSchedule do
     expect(line.pin_value_2  ).to eq(pin_value2   )
     expect(line.pin_mode     ).to eq(pin_mode     )
     expect(line.pin_time     ).to eq(pin_time     )
-    
+
   end
 
   it "handle empty command" do
@@ -254,8 +254,8 @@ describe MessageHandlerSchedule do
 
     # do the checks
 
-    expect($messaging.message[:message_type]).to eq('error')
-    
+    expect(Messaging.current.message[:message_type]).to eq('error')
+
   end
 
 # save_command_with_lines
@@ -280,7 +280,7 @@ describe MessageHandlerSchedule do
     pin_time_A      = rand(9999999).to_i
     ext_info_A      = rand(9999999).to_s
     delay_A         = rand(     99).to_i
-    
+
     action_B        = rand(9999999).to_s
     x_B             = rand(9999999).to_i
     y_B             = rand(9999999).to_i
@@ -297,11 +297,11 @@ describe MessageHandlerSchedule do
 
     # create a command
 
-    command = 
+    command =
       {
         'scheduled_time' => sched_time.utc.to_s,
         'crop_id'        => crop_id        ,
-        'command_lines'  => 
+        'command_lines'  =>
         [
           {
             'delay'  => delay_A      ,
@@ -378,7 +378,7 @@ describe MessageHandlerSchedule do
     expect(line_B.pin_value_2  ).to eq(pin_value2_B   )
     expect(line_B.pin_mode     ).to eq(pin_mode_B     )
     expect(line_B.pin_time     ).to eq(pin_time_B     )
-    
+
   end
 
   it "crop schedule update" do
@@ -401,7 +401,7 @@ describe MessageHandlerSchedule do
     pin_time_A      = rand(9999999).to_i
     ext_info_A      = rand(9999999).to_s
     delay_A         = rand(     99).to_i
-    
+
     action_B        = rand(9999999).to_s
     x_B             = rand(9999999).to_i
     y_B             = rand(9999999).to_i
@@ -432,7 +432,7 @@ describe MessageHandlerSchedule do
     pin_time_C      = rand(9999999).to_i
     ext_info_C      = rand(9999999).to_s
     delay_C         = rand(     99).to_i
-    
+
     action_D        = rand(9999999).to_s
     x_D             = rand(9999999).to_i
     y_D             = rand(9999999).to_i
@@ -453,14 +453,14 @@ describe MessageHandlerSchedule do
     message = MessageHandlerMessage.new
     message.handled = false
     message.handler = @main_handler
-    message.payload = 
+    message.payload =
       {
         'commands' =>
         [
           {
             'scheduled_time' => sched_time_AB.utc.to_s,
             'crop_id'        => crop_id_AB        ,
-            'command_lines'  => 
+            'command_lines'  =>
             [
               {
                 'delay'  => delay_A      ,
@@ -497,7 +497,7 @@ describe MessageHandlerSchedule do
           {
             'scheduled_time' => sched_time_CD.utc.to_s,
             'crop_id'        => crop_id_CD            ,
-            'command_lines'  => 
+            'command_lines'  =>
             [
               {
                 'delay'  => delay_C      ,
@@ -609,7 +609,7 @@ describe MessageHandlerSchedule do
     expect(line_D.pin_value_2  ).to eq(pin_value2_D   )
     expect(line_D.pin_mode     ).to eq(pin_mode_D     )
     expect(line_D.pin_time     ).to eq(pin_time_D     )
-    
+
   end
 
 end

--- a/spec/messaging/messagehandler_status_spec.rb
+++ b/spec/messaging/messagehandler_status_spec.rb
@@ -24,8 +24,8 @@ describe MessageHandlerStatus do
 
     $bot_control = HwStatusSim.new
 
-    $messaging = MessagingTest.new
-    $messaging.reset
+    Messaging.current = MessagingTest.new
+    Messaging.current.reset
 
     @handler = MessageHandlerStatus.new
     @main_handler = MessageHandler.new
@@ -61,7 +61,7 @@ describe MessageHandlerStatus do
     status_end_stop_x_a            = rand(9999999).to_i
     status_end_stop_x_b            = rand(9999999).to_i
     status_end_stop_y_a            = rand(9999999).to_i
-    status_end_stop_y_b            = rand(9999999).to_i 
+    status_end_stop_y_b            = rand(9999999).to_i
     status_end_stop_z_a            = rand(9999999).to_i
     status_end_stop_z_b            = rand(9999999).to_i
 
@@ -99,7 +99,7 @@ describe MessageHandlerStatus do
 
     # retrieve response message
 
-    return_msg = $messaging.message
+    return_msg = Messaging.current.message
 
     # do the checks
 
@@ -125,7 +125,7 @@ describe MessageHandlerStatus do
     expect(return_msg[:status_end_stop_y_b]            ).to eq(status_end_stop_y_b)
     expect(return_msg[:status_end_stop_z_a]            ).to eq(status_end_stop_z_a)
     expect(return_msg[:status_end_stop_z_b]            ).to eq(status_end_stop_z_b)
- 
+
   end
 
 


### PR DESCRIPTION
First attempt at reducing the number of global variables used in the project. Moved `$messaging` into a class level variable, `Messaging.current`.