### PR TITLE
Rename messaging to messenger

### DIFF
--- a/farmbot.rb
+++ b/farmbot.rb
@@ -38,8 +38,8 @@ else
 end
 puts 'OK'
 
-puts "uuid            #{Messaging.current.uuid}"
-puts "token           #{Messaging.current.token}"
+puts "uuid            #{Messenger.current.uuid}"
+puts "token           #{Messenger.current.token}"
 if $controller_disable == 0
   print 'controller      '
   require_relative 'lib/controller'

--- a/farmtalk.rb
+++ b/farmtalk.rb
@@ -27,8 +27,8 @@ print 'synchronization '
 require_relative 'lib/messaging'
 puts 'OK'
 
-puts "uuid            #{Messaging.current.uuid}"
-puts "token           #{Messaging.current.token}"
+puts "uuid            #{Messenger.current.uuid}"
+puts "token           #{Messenger.current.token}"
 
 puts 'press key to stop'
 gets.chomp

--- a/lib/messaging.rb
+++ b/lib/messaging.rb
@@ -1,3 +1,3 @@
 require_relative 'messaging/messaging'
 
-Messaging.current.start
+Messenger.current.start

--- a/lib/messaging/messaging.rb
+++ b/lib/messaging/messaging.rb
@@ -11,7 +11,7 @@ require_relative 'messagehandler.rb'
 
 # The Device class is temporarily inheriting from Tim's HardwareInterface.
 # Eventually, we should merge the two projects, but this is good enough for now.
-class Messaging
+class Messenger
   class << self
     attr_accessor :current
 

--- a/lib/messaging/messaging_test.rb
+++ b/lib/messaging/messaging_test.rb
@@ -3,7 +3,7 @@
 require 'json'
 #require_relative 'messagehandler.rb'
 
-class MessagingTest
+class MessengerTest
 
   attr_accessor :message
   attr_accessor :device

--- a/lib/messaging/web_socket.rb
+++ b/lib/messaging/web_socket.rb
@@ -22,7 +22,7 @@ module WebSocket
 
   ### Routes all skynet messages to handle_event() for interpretation.
   def create_message_event
-    socket.on(:message) { |message| Messaging.current.handle_message(message) }
+    socket.on(:message) { |message| Messenger.current.handle_message(message) }
   end
 
 end

--- a/spec/messaging/messagehandler_base_spec.rb
+++ b/spec/messaging/messagehandler_base_spec.rb
@@ -7,7 +7,7 @@ describe MessageHandlerBase do
 
 
   before do
-    messaging = MessagingTest.new
+    messaging = MessengerTest.new
     messaging.reset
 
     @handler = MessageHandlerBase.new(messaging)
@@ -17,7 +17,7 @@ describe MessageHandlerBase do
     message = MessageHandlerMessage.new
     message.handled = false
     @handler.handle_message(message)
-    expect(message.handled).to eq(false)        
+    expect(message.handled).to eq(false)
   end
 
   it "hanlde message test message" do
@@ -25,7 +25,7 @@ describe MessageHandlerBase do
     message.message_type = 'test'
     message.handled = false
     @handler.handle_message(message)
-    expect(message.handled).to eq(true)        
+    expect(message.handled).to eq(true)
   end
 
 

--- a/spec/messaging/messagehandler_emergency_stop_spec.rb
+++ b/spec/messaging/messagehandler_emergency_stop_spec.rb
@@ -14,7 +14,7 @@ describe MessageHandlerEmergencyStop do
 
     $status = Status.new
 
-    messaging = MessagingTest.new
+    messaging = MessengerTest.new
     messaging.reset
 
     @handler = MessageHandlerEmergencyStop.new(messaging)

--- a/spec/messaging/messagehandler_log_spec.rb
+++ b/spec/messaging/messagehandler_log_spec.rb
@@ -15,7 +15,7 @@ describe MessageHandlerLog do
 
     $status = Status.new
 
-    messaging = MessagingTest.new
+    messaging = MessengerTest.new
     messaging.reset
 
     @handler = MessageHandlerLog.new(messaging)

--- a/spec/messaging/messagehandler_measurements_spec.rb
+++ b/spec/messaging/messagehandler_measurements_spec.rb
@@ -15,7 +15,7 @@ describe MessageHandlerMeasurement do
 
     $status = Status.new
 
-    messaging = MessagingTest.new
+    messaging = MessengerTest.new
     messaging.reset
 
     @handler = MessageHandlerMeasurement.new(messaging)

--- a/spec/messaging/messagehandler_parameters_spec.rb
+++ b/spec/messaging/messagehandler_parameters_spec.rb
@@ -14,7 +14,7 @@ describe MessageHandlerParameter do
 
     $status = Status.new
 
-    messaging = MessagingTest.new
+    messaging = MessengerTest.new
     messaging.reset
 
     @handler = MessageHandlerParameter.new(messaging)

--- a/spec/messaging/messagehandler_schedule_spec.rb
+++ b/spec/messaging/messagehandler_schedule_spec.rb
@@ -20,7 +20,7 @@ describe MessageHandlerSchedule do
 
     $status = Status.new
 
-    messaging = MessagingTest.new
+    messaging = MessengerTest.new
     messaging.reset
 
     @handler = MessageHandlerSchedule.new(messaging)

--- a/spec/messaging/messagehandler_spec.rb
+++ b/spec/messaging/messagehandler_spec.rb
@@ -16,7 +16,7 @@ describe MessageHandler do
 
     #$status = Status.new
 
-    messaging = MessagingTest.new
+    messaging = MessengerTest.new
     messaging.reset
 
     @handler = MessageHandler.new(messaging)

--- a/spec/messaging/messagehandler_status_spec.rb
+++ b/spec/messaging/messagehandler_status_spec.rb
@@ -22,7 +22,7 @@ describe MessageHandlerStatus do
 
     $bot_control = HwStatusSim.new
 
-    messaging = MessagingTest.new
+    messaging = MessengerTest.new
     messaging.reset
 
     @handler = MessageHandlerStatus.new(messaging)


### PR DESCRIPTION
I dislike using gerunds or verbs as class names.

The next one I would like to rename is `Refresh`, but that has DB implications, so we can deal with it later.