### PR TITLE
Wording change on status messages

### DIFF
--- a/lib/controller.rb
+++ b/lib/controller.rb
@@ -147,7 +147,7 @@ class Controller
 
     else
 
-      $status.info_status = 'no command found, waiting'
+      $status.info_status = 'Awaiting commands.'
 
       @info_command_next = nil
 


### PR DESCRIPTION
Screen space is limited on the UI when displaying the status messages (especially this particular message), so I shortened the wording.