### PR TITLE
Add support for non-standard arduino mega brands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ snippet.coffee
 snippets.rb
 tmp/**/*
 *.rb~
+serial_port.txt

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ At this point, your MeshBlu credentials can be found in `credentials.yml`
 Arduino
 -------
 
+**If your device doesn't use `/dev/ttyACM0`**: Write the name of your serial device (usually /dev/ttyUSB0) in `serial_port.txt`.
+
 You will need to flash your Arduino with custom firmware. For instructions on how to do this, see [the FarmBot-Arduino github page](https://github.com/FarmBot/farmbot-serial)
 
 Author

--- a/lib/controllers/single_command_controller.rb
+++ b/lib/controllers/single_command_controller.rb
@@ -15,7 +15,7 @@ class SingleCommandController < AbstractController
 
   def call
     @cmd   = (message.payload || {})
-    key = cmd.fetch("command", {})["action"].to_s.downcase
+    key    = @cmd["action"].to_s.gsub("_", " ").downcase
     action = AVAILABLE_ACTIONS.fetch(key, :unknown).to_sym
     send(action)
     reply 'single_command', confirmation: true, command: cmd

--- a/spec/controllers/single_command_controller_spec.rb
+++ b/spec/controllers/single_command_controller_spec.rb
@@ -24,13 +24,13 @@ describe SingleCommandController do
   end
 
   it 'handles parameterless commands' do
-    commands = {"home x"          => :home_x,
-                "home y"          => :home_y,
-                "home z"          => :home_z,
-                "home all"        => :home_all,
-                "emergency stop"  => :emergency_stop }
+    commands = { "home x"         => :home_x,
+                 "home y"         => :home_y,
+                 "home z"         => :home_z,
+                 "home all"       => :home_all,
+                 "emergency stop" => :emergency_stop }
     commands.each do |key, val|
-      message.payload = {"command" => key}
+      message.payload = {"action" => key}
       controller.call
       expect(bot.commands.last).to eq(val => [])
     end


### PR DESCRIPTION
# What's New?

 * My Arduino stopped working
 * I rushed to purchase a replacement locally, but it was one of those off brands.
 * The serial port was not in `dev/ttyACM0` like usual.

# What Changed?

 * Added the ability to define to com port in `serial_port.txt`
