### PR TITLE
Upgrade meshruby, start logging online / offline events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'sqlite3'
 gem 'active_record_migrations'
 
 gem 'farmbot-serial', '0.6.0'
-gem 'meshruby', '0.0.3'
+gem 'meshruby', '0.0.4'
 gem 'mutations', '0.7.2'
 gem 'pry-byebug'
 gem 'rspec'


### PR DESCRIPTION
# What's New?

 * Added support for MeshBlu's logging capabilities
 * Send a log to the server when the bot comes on/off line.

# What's Next?

 * Figure out which logs are worth reporting. Comments welcome, @roryaronson .