### PR TITLE
End the status polling reign of terror

### DIFF
--- a/lib/bot_decorator.rb
+++ b/lib/bot_decorator.rb
@@ -42,6 +42,7 @@ module FBPi
 
     def diffmessage(diff)
       @status_storage.update_attributes(diff)
+      mesh.emit '*', FBPi::FetchBotStatus.run!(bot: self)
       log "BOT DIF: #{diff}" unless diff.keys == [:BUSY]
     end
 

--- a/lib/command_objects/sync_bot.rb
+++ b/lib/command_objects/sync_bot.rb
@@ -14,11 +14,9 @@ module FBPi
           .tap { Schedule.destroy_all }
           .map { |s| CreateSchedule.run!(s) }
       end
-      bot.log(name: "Sync Confirmation",
-              schedules: Schedule.count,
-              sequences: Sequence.count,
-              steps:     Step.count)
-      Schedule.all
+      {schedules: Schedule.count,
+       sequences: Sequence.count,
+       steps:     Step.count}
     rescue FbResource::FetchError => e
       add_error :web_server, :fetch_error, e.message
     end

--- a/lib/farmbot-pi.rb
+++ b/lib/farmbot-pi.rb
@@ -42,7 +42,6 @@ class FarmBotPi
       broadcast_status
       mesh.onmessage { |msg| meshmessage(msg) }
       bot.bootstrap
-      FBPi::SyncBot.run(bot: bot)
     end
   end
 
@@ -57,7 +56,11 @@ class FarmBotPi
   end
 
   def broadcast_status
-    EventMachine::PeriodicTimer.new(0.4) do
+    # TODO: Add onconnect() hook instead of timers. Was having issues with
+    # socketio client previously.
+    EventMachine::Timer.new(4) do
+      sync = FBPi::SyncBot.run(bot: bot).result
+      mesh.emit '*', { method: 'sync_sequence', id: nil, params: sync } if sync
       mesh.emit '*', FBPi::FetchBotStatus.run!(bot: bot)
     end
   end


### PR DESCRIPTION
# What's New?

 * Bot status was once delivered via status polling every 300 ms
 * This was CPU and IO intensive

# What Changed?

 * Bot only emits status when a change occurs, greatly reducing the number of network / event loop requests needed.