### PR TITLE
Change status broadcast format to allow for `notification` and `response` type messages

### DIFF
--- a/lib/bot_decorator.rb
+++ b/lib/bot_decorator.rb
@@ -42,7 +42,8 @@ module FBPi
 
     def diffmessage(diff)
       @status_storage.update_attributes(diff)
-      mesh.emit '*', FBPi::FetchBotStatus.run!(bot: self)
+      stats = FBPi::FetchBotStatus.run!(bot: self)
+      mesh.emit '*', { method: 'read_status', params: stats, id: nil }
       log "BOT DIF: #{diff}" unless diff.keys == [:BUSY]
     end
 

--- a/lib/command_objects/fetch_bot_status.rb
+++ b/lib/command_objects/fetch_bot_status.rb
@@ -11,11 +11,7 @@ module FBPi
     end
 
     def execute
-      {
-        method: 'read_status',
-        params: status_hash,
-        id: nil # Must be nil to conform to JSONRPC 1.0
-      }
+      status_hash
     end
 
 private


### PR DESCRIPTION
Minor fix to handle response objects. Prior version only supported 'notification' type messages.