### PR TITLE
Fix out-of-order step execution bug

### DIFF
--- a/db/migrate/20150703184419_add_position_to_step.rb
+++ b/db/migrate/20150703184419_add_position_to_step.rb
@@ -1,0 +1,5 @@
+class AddPositionToStep < ActiveRecord::Migration
+  def change
+    add_column :steps, :position, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150504131720) do
+ActiveRecord::Schema.define(version: 20150703184419) do
 
   create_table "schedules", force: :cascade do |t|
     t.integer  "sequence_id"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 20150504131720) do
     t.integer  "sequence_id"
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
+    t.integer  "position"
   end
 
 end

--- a/lib/command_objects/create_step.rb
+++ b/lib/command_objects/create_step.rb
@@ -4,6 +4,7 @@ module FBPi
   class CreateStep < Mutations::Command
     required do
       string :message_type, in: Step::COMMANDS
+      integer :position
       hash :command do
         optional do
           [:x, :y, :z, :speed, :pin, :value, :mode].each do |f|

--- a/lib/controllers/exec_sequence_controller.rb
+++ b/lib/controllers/exec_sequence_controller.rb
@@ -4,7 +4,10 @@ require_relative '../command_objects/commands'
 module FBPi
   class ExecSequenceController < AbstractController
     def call
-      sequence.steps.each { |step| step.execute(bot) }
+      sequence
+        .steps
+        .sort{ |a, b| a.position <=> b.position}
+        .each { |step| step.execute(bot) }
       reply "exec_sequence", params
     rescue Mutations::ValidationException => error
       reply "error", error: error.message

--- a/lib/models/step.rb
+++ b/lib/models/step.rb
@@ -16,7 +16,7 @@ class Step < ActiveRecord::Base
          "wait"          => :wait}
     key = r[message_type.to_s] || :unknown
     puts "EXECUTING #{key}"
-    self.send(key), bot
+    self.send(key, bot)
   end
 
   def move_relative(bot)

--- a/lib/models/step.rb
+++ b/lib/models/step.rb
@@ -14,7 +14,9 @@ class Step < ActiveRecord::Base
          "pin_write"     => :pin_write,
          "unknown"       => :unknown,
          "wait"          => :wait}
-    self.send (r[message_type.to_s] || :unknown), bot
+    key = r[message_type.to_s] || :unknown
+    puts "EXECUTING #{key}"
+    self.send(key), bot
   end
 
   def move_relative(bot)
@@ -40,8 +42,14 @@ class Step < ActiveRecord::Base
     # Possibly relevant: http://www.rubydoc.info/github/igrigorik
     #                    /em-synchrony/EventMachine%2FSynchrony.sleep
     # -- rickcarlino
-    millis = (value || 0) / 1000.0
+    seconds = (value || 0) / 1000.0
+    actual  =
+    puts "Starting #{seconds} second wait"
+    early = Time.now
     sleep(millis)
+    late = Time.now
+    puts "Ending #{seconds} second wait."
+    puts "Actual time: #{late - early}"
   end
 
   def unknown(bot)

--- a/lib/models/step.rb
+++ b/lib/models/step.rb
@@ -42,14 +42,7 @@ class Step < ActiveRecord::Base
     # Possibly relevant: http://www.rubydoc.info/github/igrigorik
     #                    /em-synchrony/EventMachine%2FSynchrony.sleep
     # -- rickcarlino
-    seconds = (value || 0) / 1000.0
-    actual  =
-    puts "Starting #{seconds} second wait"
-    early = Time.now
-    sleep(millis)
-    late = Time.now
-    puts "Ending #{seconds} second wait."
-    puts "Actual time: #{late - early}"
+    sleep((value || 0) / 1000.0)
   end
 
   def unknown(bot)


### PR DESCRIPTION
I wasn't sorting steps by their `position` key. Whoops!