### PR TITLE
Prevent malformed RPC messages from crashing bot

### DIFF
--- a/lib/messaging/message_handler.rb
+++ b/lib/messaging/message_handler.rb
@@ -14,6 +14,8 @@ module FBPi
     ## general handling messages
     def initialize(message_hash, bot, mesh)
       @bot, @mesh, @message = bot, mesh, BuildMeshMessage.run!(message_hash)
+    rescue Mutations::ValidationException => e
+      send_error(e)
     end
 
     def call


### PR DESCRIPTION
# Why?

 * Made first contact with FarmbotJS
 * .... but sent the bot a malformed message
 * Farmbot "fails hard" on bad messages (for easier debugging)
 * Nothing caught the exception, so the bot crashed.

# What Changed?

 * Bad messages are not routed to the exception handler.
 