### PR TITLE
DRY up serialization logic for fetching and reading of status

### DIFF
--- a/lib/command_objects/cold_start.rb
+++ b/lib/command_objects/cold_start.rb
@@ -12,9 +12,9 @@ module FBPi
     end
 
     def execute
-      set_event_handlers
       pull_up_stored_parameters_from_disk
       FetchBotStatus.run!(bot: bot)
+      set_event_handlers
       bot
     end
 

--- a/lib/command_objects/fetch_bot_status.rb
+++ b/lib/command_objects/fetch_bot_status.rb
@@ -18,7 +18,7 @@ module FBPi
     def execute
       read_pins
       read_parameters
-      bot.status.to_h
+      FBPi::ReportBotStatus.run!(bot: bot)
     end
 
     def read_pins

--- a/lib/command_objects/report_bot_status.rb
+++ b/lib/command_objects/report_bot_status.rb
@@ -3,7 +3,7 @@ require 'mutations'
 module FBPi
   # This class reads bot status information that has been cached by the Pi. This
   # should not be confused with FetchBotStatus, which actively requests status
-  # updates from the bot. It will return a Hash that has all relevant
+  # updates from the bot. This command will return a Hash that has all relevant
   # information known about the bot
   class ReportBotStatus < Mutations::Command
     required do
@@ -14,34 +14,29 @@ module FBPi
       # TODO: Replace everything here with just `bot.status.to_h`. Can't right
       # now because it will be a breaking change to the web app.
       {}
-        .merge(status_info)
+        .merge(bot_info)
         .merge(pin_info)
-        .merge(other_info)
+        .merge(pi_info)
         .deep_symbolize_keys
     end
 
 private
 
-    def other_info
+    def bot_info
       bot
         .status
         .to_h
-        .except(:X, :Y, :Z, :BUSY, :LAST, :PINS, :S)
+        .except(:PINS)
+        .delete_if { |k, v| k.to_s.start_with?("UNKNOWN") }
     end
 
-    def status_info
-      { busy:            bot.status[:busy],
-        current_command: bot.status[:last],
-        x:               bot.status[:x],
-        y:               bot.status[:y],
-        z:               bot.status[:z],
-        s:               bot.status[:s],
-        last_sync:       bot.status_storage.fetch(:pi, :last_sync) }
+    def pi_info
+      { LAST_SYNC: bot.status_storage.fetch(:pi, :last_sync) }
     end
 
     def pin_info
       [*0..13].inject({}) do |hsh, pin|
-        hsh["pin#{pin}".to_sym] = bot.status.get_pin(pin)
+        hsh["PIN#{pin}".to_sym] = bot.status.get_pin(pin)
         hsh
       end
     end

--- a/spec/command_objects/fetch_bot_status_spec.rb
+++ b/spec/command_objects/fetch_bot_status_spec.rb
@@ -18,6 +18,8 @@ describe FBPi::FetchBotStatus do
   it "executes" do
     expect(obj).to receive(:read_pins)
     expect(obj).to receive(:read_parameters)
-    expect(obj.execute).to eq(bot.status.to_h)
+    results = obj.execute
+    missing_keys = bot.status.to_h.except(:PINS).keys - results.keys
+    expect(missing_keys.length).to eq(0)
   end
 end

--- a/spec/controllers/read_status_controller_spec.rb
+++ b/spec/controllers/read_status_controller_spec.rb
@@ -25,7 +25,7 @@ describe FBPi::ReadStatusController do
     msg = mesh.last.params
     expect(msg[:result][:method]).to eq("read_status")
     keys = msg[:result]
-    [:busy, :current_command, :x, :y, :z].each do |key|
+    [:BUSY, :LAST, :X, :Y, :Z].each do |key|
       expect(keys).to include(key)
     end
   end


### PR DESCRIPTION
# What's New?

 * Avoiding getting rate limited by MeshBlu
 * DRY up logic that was duplicated in two places when reporting bot status.

