### PR TITLE
Make all outbound keys lowercase

### DIFF
--- a/lib/command_objects/report_bot_status.rb
+++ b/lib/command_objects/report_bot_status.rb
@@ -11,13 +11,12 @@ module FBPi
     end
 
     def execute
-      # TODO: Replace everything here with just `bot.status.to_h`. Can't right
-      # now because it will be a breaking change to the web app.
       {}
         .merge(bot_info)
         .merge(pin_info)
         .merge(pi_info)
         .deep_symbolize_keys
+
     end
 
 private
@@ -28,16 +27,18 @@ private
         .to_h
         .except(:PINS)
         .delete_if { |k, v| k.to_s.start_with?("UNKNOWN") }
+        .map { |k, v| [k.to_s.downcase, v] }
+        .to_h
     end
 
     def pi_info
-      { LAST_SYNC:  bot.status_storage.fetch(:pi, :LAST_SYNC),
-        IP_ADDRESS: bot.status_storage.fetch(:pi, :IP_ADDRESS) }
+      { last_sync:  bot.status_storage.fetch(:pi, :LAST_SYNC),
+        ip_address: bot.status_storage.fetch(:pi, :IP_ADDRESS) }
     end
 
     def pin_info
       [*0..13].inject({}) do |hsh, pin|
-        hsh["PIN#{pin}".to_sym] = bot.status.get_pin(pin)
+        hsh["pin#{pin}".to_sym] = bot.status.get_pin(pin)
         hsh
       end
     end

--- a/lib/controllers/single_command_controller.rb
+++ b/lib/controllers/single_command_controller.rb
@@ -53,8 +53,6 @@ module FBPi
     end
 
     def pin_write
-      # "Known Good" method calls:
-      # write_pin(pin: 13, value: 0, mode: 0)
       # write_pin(pin: 13, value: 1, mode: 0)
       bot.commands.write_pin(pin: cmd['pin'],
                  value: cmd['value1'],


### PR DESCRIPTION
# Why?

 * The bot was sending status keys `UPCASE` in some places and `downcase` in others.

# What's New?

 * Always sends keys `downcase`