### PR TITLE
Routine updates, 10 April

### DIFF
--- a/lib/command_objects/cold_start.rb
+++ b/lib/command_objects/cold_start.rb
@@ -22,8 +22,6 @@ module FBPi
       bot.onmessage { |msg| botmessage(msg) }
       bot.onchange  { |msg| diffmessage(msg) }
       bot.onclose   { |msg| close(msg) }
-      # Why `bott`? Because of unexpected behavior in socket-io-client-simple.
-      bott = bot; bot.mesh.socket.on(:ready) { bott.ready }
     end
 
     def pull_up_stored_parameters_from_disk
@@ -42,8 +40,10 @@ module FBPi
     def diffmessage(diff)
       bot.status_storage.update_attributes(:bot, diff)
       # Broadcasting busy status changes result in too much network 'noise'.
-      bot.emit_changes unless (diff.keys == [:BUSY])
-      bot.log "BOT DIF: #{diff}"
+      if (diff.keys != [:BUSY])
+        bot.emit_changes
+        bot.log "BOT DIF: #{diff}"
+      end
     end
 
     def close()

--- a/lib/farmbot-pi.rb
+++ b/lib/farmbot-pi.rb
@@ -28,6 +28,7 @@ class FarmBotPi
 
   def start
     EM.run do
+        bot.bootstrap
         mqtt.connect { |msg| mqttmessage(msg) }
         FB::ArduinoEventMachine.connect(bot)
         start_chore_runner
@@ -36,6 +37,7 @@ class FarmBotPi
   end
 
   def mqttmessage(msg)
+    puts msg.payload
     FBPi::MessageHandler.call(msg, bot, mqtt)
   end
 

--- a/lib/messaging/mqtt.rb
+++ b/lib/messaging/mqtt.rb
@@ -12,6 +12,7 @@ class MQTTAdapter
   end
 
   def connect(&blk)
+    puts "Conencting to #{@host}:#{@port}"
     @client = EventMachine::MQTT::ClientConnection.connect(host:     @host,
                                                            port:     @port,
                                                            username: @username,

--- a/setup.rb
+++ b/setup.rb
@@ -58,4 +58,6 @@ else
 end
 puts "Installing dependencies"
 `bundle install`
-puts "Setup is complete! You may now run `ruby farmbot.rb` to initialize the bot."
+puts "Setup is complete! You may now run `ruby farmbot.rb` to start the bot."
+run_confirm = app.agree("Want to run `ruby farmbot.rb` now?", true)
+load 'farmbot.rb' if run_confirm


### PR DESCRIPTION
# What's New?

 * Ask the user if they want to run the bot after running setup
 * Reinstate use of `bootstrap()` on boot up.