### PR TITLE
Prevent transmission of malformed status messages.

### DIFF
--- a/lib/command_objects/cold_start.rb
+++ b/lib/command_objects/cold_start.rb
@@ -19,7 +19,7 @@ module FBPi
     end
 
     def set_event_handlers
-      bot.onmessage { |msg| botmessage(msg) }
+      # bot.onmessage { |msg| /# not needed anymore, except for debugging #/ } 
       bot.onchange  { |msg| diffmessage(msg) }
       bot.onclose   { |msg| close(msg) }
     end
@@ -32,10 +32,6 @@ module FBPi
           param_number = param_names.fetch(k, k)
           bot.commands.write_parameter(param_number, v) }
       end
-    end
-
-    def botmessage(msg)
-      # Callbacks here, yo.
     end
 
     def diffmessage(diff)

--- a/lib/farmbot-pi.rb
+++ b/lib/farmbot-pi.rb
@@ -31,7 +31,6 @@ class FarmBotPi
         mqtt.connect { |msg| mqttmessage(msg) }
         FB::ArduinoEventMachine.connect(bot)
         start_chore_runner
-        broadcast_status
     end
   end
 
@@ -44,16 +43,6 @@ class FarmBotPi
     EventMachine::PeriodicTimer.new(FBPi::ChoreRunner::INTERVAL) do
       # TODO: Add chore to check validity of session token / refresh as needed.
       FBPi::ChoreRunner.new(bot).run
-    end
-  end
-
-  def broadcast_status
-    # TODO: Add onconnect() hook instead of timers. Was having issues with
-    # socketio client previously (we dont use it anymore).
-    EventMachine::Timer.new(4) do
-      sync = FBPi::SyncBot.run(bot: bot).result
-      mqtt.emit '*', { method: 'sync_sequence', id: nil, params: sync } if sync
-      mqtt.emit '*', FBPi::ReportBotStatus.run!(bot: bot)
     end
   end
 end

--- a/spec/command_objects/cold_start_spec.rb
+++ b/spec/command_objects/cold_start_spec.rb
@@ -60,13 +60,6 @@ describe FBPi::ColdStart do
     expect(goodbye).to include("Bot offline at #{Date.today}")
   end
 
-  it 'does not log idle messages' do
-    msg = FB::Gcode.new { "R00 A1" }
-    logger = bot.logger
-    obj.botmessage(msg)
-    expect(logger.message).to eq("")
-  end
-
   it 'transmits status diff messages' do
     obj.diffmessage(X: 123)
     expect(bot.status_storage.to_h(:bot)[:X]).to eq(123)


### PR DESCRIPTION
# Why?

 * The bot was sending the browser malformed messages, which was making debugging harder and muddying up `state.bot` with useless keys.

# What Changed?

 * Fixed the problem.

