### PR TITLE
Re-institute syncing on new version of API.

### DIFF
--- a/lib/command_objects/create_plant.rb
+++ b/lib/command_objects/create_plant.rb
@@ -5,13 +5,13 @@ module FBPi
   # Ruby objects, save them in SQLite.
   class CreatePlant < Mutations::Command
     required do
-      string  :_id
+      string  :id
       integer :x
       integer :y
     end
 
     def validate
-      inputs[:id_on_web_app] = inputs.delete(:_id)
+      inputs[:id_on_web_app] = inputs.delete(:id)
     end
 
     def execute

--- a/lib/command_objects/create_schedule.rb
+++ b/lib/command_objects/create_schedule.rb
@@ -9,7 +9,7 @@ module FBPi
   class CreateSchedule < Mutations::Command
     required do
       string :start_time
-      string :_id
+      string :id
       string :end_time
       float  :repeat
       string :time_unit, in: Schedule::UNITS_OF_TIME
@@ -21,7 +21,7 @@ module FBPi
     end
 
     def validate
-      inputs[:id_on_web_app] = inputs.delete(:_id)
+      inputs[:id_on_web_app] = inputs.delete(:id)
       inputs[:sequence] = Sequence.find_by!(id_on_web_app:
                                             inputs.delete(:sequence_id))
     end

--- a/lib/command_objects/create_sequence.rb
+++ b/lib/command_objects/create_sequence.rb
@@ -6,12 +6,12 @@ module FBPi
   class CreateSequence < Mutations::Command
     required do
       string :name
-      string :_id
+      string :id
       array(:steps) { model :step, builder: CreateStep, new_records: true }
     end
 
     def execute
-      Sequence.create!(inputs.merge!(id_on_web_app: inputs.delete(:_id)))
+      Sequence.create!(inputs.merge!(id_on_web_app: inputs.delete(:id)))
     end
   end
 end

--- a/lib/command_objects/sync_bot.rb
+++ b/lib/command_objects/sync_bot.rb
@@ -21,6 +21,8 @@ module FBPi
       puts "Done with sync..."
     rescue FbResource::FetchError => e
       add_error :web_server, :fetch_error, e.message
+    rescue => e
+      add_error :sync_issues, :fetch_error, e.message
     end
 
     def after_sync(data)


### PR DESCRIPTION
# Why?

 * RPi expected legacy `_id` attribute from MongoDB, but SQL uses `id` primary keys.

# What Changed?

 * Removed `_id` references.
